### PR TITLE
fix: open in app_url functionality

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -2,4 +2,4 @@
 
 
 def app_url(browser_url):
-    return browser_url.replace("https://www.notion.so/", "notion://")
+    return browser_url.replace("https://", "notion://")


### PR DESCRIPTION
It turns out you have to keep the `www.notion.so` part in the url for
the page to open in the desktop application.

This changed a few months back and I even confirmed with the Notion
support team that this was an issue. Turns out things just changed. This
change now make it behave as expected.